### PR TITLE
feat: centralize youtube request headers

### DIFF
--- a/src/utils/innertubeHelper.js
+++ b/src/utils/innertubeHelper.js
@@ -1,4 +1,5 @@
 import { Innertube } from 'youtubei.js';
+import webScrapingHelper, { getYoutubeCookieString, YOUTUBE_DEFAULT_QUERY_PARAMS } from './webScrapingHelper.js';
 
 /**
  * InnerTube.js Helper - Uses YouTube's internal API
@@ -26,8 +27,19 @@ class InnerTubeHelper {
     try {
       console.log('Initializing Innertube client...');
       // Add timeout to client initialization
+      const innertubeOptions = {
+        lang: YOUTUBE_DEFAULT_QUERY_PARAMS.hl,
+        location: YOUTUBE_DEFAULT_QUERY_PARAMS.gl,
+        user_agent: webScrapingHelper.getRandomUserAgent()
+      };
+
+      const cookie = getYoutubeCookieString();
+      if (cookie) {
+        innertubeOptions.cookie = cookie;
+      }
+
       this.client = await Promise.race([
-        Innertube.create(),
+        Innertube.create(innertubeOptions),
         new Promise((_, reject) =>
           setTimeout(() => reject(new Error('Innertube client initialization timeout')), 3000)
         )


### PR DESCRIPTION
## Summary
- add helpers to build standardized YouTube request headers, cookies, and language parameters for scraping
- reuse the new helper for ytdl-core and Innertube clients so every request carries the consent bypass cookies

## Testing
- npm test
- npm run lint *(fails: ESLint configuration missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d123286e90832382901f6c60125502